### PR TITLE
feat: offline token validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ junit.xml
 /package-lock.json
 oclif.manifest.json
 .vscode
+.idea

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-errors": "^3.0.1",
     "@adobe/aio-lib-core-logging": "^1.1.1",
+    "@adobe/aio-lib-core-networking": "^2.0.0",
     "jsonwebtoken": "^8.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-errors": "^3.0.1",
     "@adobe/aio-lib-core-logging": "^1.1.1",
-    "jsonwebtoken": "^8.3.0"
+    "jsonwebtoken": "^8.5.1"
   },
   "peerDependencies": {
     "@adobe/aio-lib-ims": "^4.0.0"

--- a/src/errors.js
+++ b/src/errors.js
@@ -45,5 +45,6 @@ module.exports = {
 
 // Define your error codes with the wrapper
 E('INVALID_KEY', 'Cannot sign the JWT, the private key or the passphrase is invalid')
+E('INVALID_TOKEN', 'Cannot validate the provided token')
 E('INVALID_KEY_FILE', 'content of file \'%s\' is not a valid private key')
 E('MISSING_PROPERTIES', 'JWT not supported due to some missing properties: %s')

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -112,7 +112,7 @@ async function getPrivateKey (env, certName) {
  * Validates provided token using an IMS public key cert.
  *
  * @param {string} token Jwt token you want to validate. It validates only the access_token type.
- * @returns {Promise<void>} The jwt token if valid
+ * @returns {Promise<void>} Will throw if token is invalid
  */
 async function verifyJwt (token) {
   try {

--- a/src/ims-jwt.js
+++ b/src/ims-jwt.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { createJwt } = require('./helpers')
+const { createJwt, verifyJwt } = require('./helpers')
 const { codes: errors } = require('./errors')
 
 /**
@@ -71,5 +71,6 @@ async function imsLogin (ims, config) {
 module.exports = {
   canSupport,
   supports: canSupportSync,
-  imsLogin
+  imsLogin,
+  verifyJwt
 }

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 const { parseJson, createJwt, verifyJwt } = require('../src/helpers')
 const jwt = require('jsonwebtoken')
-jest.mock('@adobe/aio-lib-env')
 const mockExponentialBackoff = jest.fn()
 jest.mock('@adobe/aio-lib-core-networking', () => ({
   HttpExponentialBackoff: jest.fn().mockImplementationOnce(() => ({

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -10,10 +10,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { parseJson, createJwt } = require('../src/helpers')
-const jwt = require('jsonwebtoken')
+const { parseJson, createJwt, verifyJwt } = require('../src/helpers')
 
-jest.mock('jsonwebtoken')
+const jwt = require('jsonwebtoken')
+jest.mock('jsonwebtoken', () => ({
+  decode: jest.fn(),
+  verify: jest.fn(),
+  sign: jest.fn()
+}))
+
+const https = require('https')
+jest.mock('https', () => ({
+  get: jest.fn()
+}))
 
 const gIms = {
   exchangeJwtToken: jest.fn(),
@@ -21,14 +30,33 @@ const gIms = {
 }
 
 jest.mock('fs', () => ({
-  readFile: jest.fn()
+  readFile: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn()
 }))
 const fs = require('fs')
 
 beforeEach(() => {
   jest.restoreAllMocks()
   fs.readFile.mockReset()
+  fs.readFileSync.mockReset()
+  fs.writeFileSync.mockReset()
+  jwt.verify.mockReset()
+  jwt.decode.mockReset()
+  jwt.sign.mockReset()
+  https.get.mockReset()
 })
+
+const mockGetRes = {
+  on: jest.fn().mockImplementation((event, cb) => {
+    if (event === 'data') {
+      cb()
+    }
+    if (event === 'end') {
+      cb()
+    }
+  })
+}
 
 test('parseJson', () => {
   const myString = 'some-string'
@@ -111,4 +139,125 @@ test('createJwt', async () => {
   })
   jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, myConfig.meta_scopes, myConfig.private_key, myConfig.passphrase)
   await expect(jwtObject).rejects.toThrow('[IMSJWTSDK:INVALID_KEY] Cannot sign the JWT, the private key or the passphrase is invalid')
+})
+
+describe('verifyJwt', () => {
+  test('verifyJwt, cached cert, jwt.verify called', async () => {
+    const privateKey = '-----BEGIN PRIVATE KEY-----'
+    const myAccessToken = 'my-access-token'
+    jwt.verify.mockImplementation(() => true)
+    jwt.decode.mockImplementation(() => ({
+      header: { x5u: 'myCertName' },
+      payload: { type: 'access_token', state: '{"env": "prod"}' }
+    }))
+    fs.readFileSync.mockImplementation(() => privateKey)
+    await verifyJwt(myAccessToken)
+    expect(jwt.verify).toHaveBeenCalledWith(myAccessToken, privateKey, { algorithms: ['RS256'] })
+    expect(verifyJwt).not.toThrow()
+  })
+  test('verifyJwt, get new cert, valid cert,', async () => {
+    const privateKey = '-----BEGIN PRIVATE KEY-----'
+    const myAccessToken = 'my-access-token'
+    const decodedToken = {
+      header: { x5u: 'myCertName' },
+      payload: { type: 'access_token', state: '{"env": "prod"}' }
+    }
+    jwt.decode = jest.fn().mockImplementation(() => decodedToken)
+    jwt.verify = jest.fn().mockImplementation(() => true)
+    fs.writeFileSync.mockImplementation(() => true)
+    fs.readFileSync.mockImplementation(() => { throw new Error() })
+    const mockGetRes = {
+      on: jest.fn().mockImplementation((event, cb) => {
+        if (event === 'data') {
+          cb(privateKey)
+        }
+        if (event === 'end') {
+          cb()
+        }
+      })
+    }
+    https.get.mockImplementation((option, cb) => {
+      cb(mockGetRes)
+    })
+    await expect(verifyJwt(myAccessToken)).resolves.not.toThrow()
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expect.any(String), privateKey)
+    expect(jwt.verify).toHaveBeenCalledWith(myAccessToken, privateKey, { algorithms: ['RS256'] })
+  })
+  test('verifyJwt, get new cert, invalid response,', async () => {
+    const privateKey = '-----BEGIN PRIVATE KEY-----'
+    const myAccessToken = 'my-access-token'
+    https.get.mockImplementation((option, cb) => {
+      cb(mockGetRes)
+    })
+    jwt.decode.mockImplementation(() => ({
+      header: { x5u: 'myCertName' },
+      payload: { type: 'access_token', state: '{"env": "prod"}' }
+    }))
+    jwt.verify.mockImplementation(() => true)
+    fs.readFileSync.mockImplementation(() => {
+      throw new Error()
+    })
+    await expect(verifyJwt(myAccessToken)).rejects.toThrow()
+    expect(jwt.verify).not.toHaveBeenCalledWith(myAccessToken, privateKey, { algorithms: ['RS256'] })
+  })
+  test('verifyJwt, get new cert, reject on error,', async () => {
+    const privateKey = '-----BEGIN PRIVATE KEY-----'
+    const myAccessToken = 'my-access-token'
+    const mockGetRes = {
+      on: jest.fn().mockImplementation((event, cb) => {
+        if (event === 'data') {
+          cb()
+        }
+        if (event === 'end') {
+          cb()
+        }
+        if (event === 'error') {
+          cb(new Error('failed'))
+        }
+      })
+    }
+    https.get.mockImplementation((option, cb) => {
+      cb(mockGetRes)
+    })
+    jwt.decode.mockImplementation(() => ({
+      header: { x5u: 'myCertName' },
+      payload: { type: 'access_token', state: '{"env": "prod"}' }
+    }))
+    jwt.verify.mockImplementation(() => true)
+    fs.readFileSync.mockImplementation(() => {
+      throw new Error()
+    })
+    await expect(verifyJwt(myAccessToken)).rejects.toThrow()
+    expect(jwt.verify).not.toHaveBeenCalledWith(myAccessToken, privateKey, { algorithms: ['RS256'] })
+  })
+  test('verifyJwt, _readOrGetCert invalid params, reject,', async () => {
+    jwt.decode.mockImplementation(() => ({
+      header: { x5u: '' },
+      payload: { type: 'access_token', state: '{"env": ""}' }
+    }))
+    jwt.verify.mockImplementation(() => true)
+    fs.readFileSync.mockImplementation(() => {
+      throw new Error()
+    })
+    await expect(verifyJwt('token')).rejects.toThrow()
+    expect(jwt.verify).not.toHaveBeenCalled()
+  })
+  test('verifyJwt, not access token, skip verify,', async () => {
+    jwt.decode.mockImplementation(() => ({
+      header: { x5u: '' },
+      payload: { type: 'not_access', state: '{"env": ""}' }
+    }))
+    jwt.verify.mockImplementation(() => true)
+    fs.readFileSync.mockImplementation(() => {
+      throw new Error()
+    })
+    await expect(verifyJwt('token')).resolves.not.toThrow()
+    expect(jwt.verify).not.toHaveBeenCalled()
+  })
+  test('verifyJwt, throw with invalid key', async () => {
+    const privateKey = ''
+    const myAccessToken = 'my-access-token'
+    fs.readFileSync.mockImplementation(() => privateKey)
+    await expect(verifyJwt(myAccessToken)).rejects.toThrow()
+  })
 })


### PR DESCRIPTION
Added offline token validation method.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR requires changes in `aio-lib-ims`: https://github.com/adobe/aio-lib-ims/pull/92

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/386

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests.

Manual QA. 
Steps: 
1. Login via `aio auth`.
2. Modify `access_token`. 
3. `aio app init`

Expected: 
- Refresh token is used to generate new `access_token`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
